### PR TITLE
FUSETOOLS2-869 - fix completion for didact link with started words

### DIFF
--- a/src/didactUriCompletionItemProvider.ts
+++ b/src/didactUriCompletionItemProvider.ts
@@ -119,14 +119,8 @@ export class DidactUriCompletionItemProvider implements vscode.CompletionItemPro
 		completionItem.insertText = DIDACT_COMMAND_PREFIX;
 		completionItem.documentation = new vscode.MarkdownString(docs);
 		completionItem.command = command;
-		completionItem.filterText
-		
-		const range = this.getWholeDidactString(document, position);
-		if (range) {
-			completionItem.additionalTextEdits = [
-				vscode.TextEdit.delete(range)
-			];
-		}
+		completionItem.filterText = DIDACT_COMMAND_PREFIX;
+		completionItem.range = this.getWholeDidactString(document, position);
 		return completionItem;
 	}
 

--- a/src/test/suite/didactUriCompletionItemProvider.test.ts
+++ b/src/test/suite/didactUriCompletionItemProvider.test.ts
@@ -60,14 +60,14 @@ suite("Didact URI completion provider tests", function () {
 
 	test("that completions work the way they should", async () => {
 		const listOfCompletions : string[] = [
-			'[My Link](didact',
 			'[My Link](didact:',
 			'[My Link](didact:/',
 			'[My Link](didact://',
 			'[My Link](didact://?',
 			'[My Link](didact://?c',
 			'[My Link](didact://?co',
-			'[My Link](didact://?com'
+			'[My Link](didact://?com',
+			'[My Link](didact'
 		];
 
 		suite('walk through each provided completion', () => {


### PR DESCRIPTION
tl;dr; :
- needs to provide the filterText as the label is not corresponding to
the insertText
- needs to provide the range as the completion englobes what is before
the character calling for completion
- no need of explicit delete action, specifying the range is enough


tests needs to be adjusted for 2 cases:
- the first in the list can take few seconds on first call to show up.
using a waitUntil will fix the issue
- `[My Link](didact` is not working because there is another completion
provided which is the one preselected and so the one picked during
tests. Moved it to the end of the test because the tests are not
cleaning the file correctly when failing.

the tests would need to get rid of all delay and use conditional wait.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>